### PR TITLE
enable large file upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ site
 
 # E2E
 venv
+temp

--- a/omlmd/helpers.py
+++ b/omlmd/helpers.py
@@ -100,6 +100,7 @@ class Helper:
                 files=files,
                 manifest_annotations=model_metadata.to_annotations_dict(),
                 manifest_config=manifest_cfg,
+                do_chunked=True,
             )
             self.notify_listeners(PushEvent(target, model_metadata))
             return result

--- a/poetry.lock
+++ b/poetry.lock
@@ -1456,13 +1456,13 @@ files = [
 
 [[package]]
 name = "oras"
-version = "0.2.1"
+version = "0.2.21"
 description = "OCI Registry as Storage Python SDK"
 optional = false
 python-versions = "*"
 files = [
-    {file = "oras-0.2.1-py3-none-any.whl", hash = "sha256:a430f9ef70740246289e01cf5a4f551b985c762c661768bce955eb54766918bb"},
-    {file = "oras-0.2.1.tar.gz", hash = "sha256:d4bc1d1acc9b19ee6ac0f0e4b4723349a334d4eb44298a7931464b4b2b79b174"},
+    {file = "oras-0.2.21-py3-none-any.whl", hash = "sha256:4564d55c417b2fd62d5c5578458d1bfbb69f5c527f1c673b803211c50cf284b4"},
+    {file = "oras-0.2.21.tar.gz", hash = "sha256:ea0a4fe180cf825967dd00999c7dec0a2e34cb963c9aa4b270132a811684c1bd"},
 ]
 
 [package.dependencies]
@@ -2567,4 +2567,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "954cb5d27420e36fdf46c85b784d355ba3858f07f31f7155455e1eb7fb65596d"
+content-hash = "c3c3ce57a4d5970244462ebea539e02dc5175cfaf68b495a6dabb66909c342f0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1456,13 +1456,13 @@ files = [
 
 [[package]]
 name = "oras"
-version = "0.1.30"
+version = "0.2.1"
 description = "OCI Registry as Storage Python SDK"
 optional = false
 python-versions = "*"
 files = [
-    {file = "oras-0.1.30-py3-none-any.whl", hash = "sha256:57671f8f619a213a9482e7511c3a5685519d734da2850d2a0ff3286fb82670af"},
-    {file = "oras-0.1.30.tar.gz", hash = "sha256:e4d8d9023e0e0fa1bd2c6332b7a14da90cfda63674907868a9364dcf2bee3fa1"},
+    {file = "oras-0.2.1-py3-none-any.whl", hash = "sha256:a430f9ef70740246289e01cf5a4f551b985c762c661768bce955eb54766918bb"},
+    {file = "oras-0.2.1.tar.gz", hash = "sha256:d4bc1d1acc9b19ee6ac0f0e4b4723349a334d4eb44298a7931464b4b2b79b174"},
 ]
 
 [package.dependencies]
@@ -2567,4 +2567,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "528edb40f371fdf53dcda30256f6a2d5bab38f7a994dd4029e253de0ad9dd8c4"
+content-hash = "954cb5d27420e36fdf46c85b784d355ba3858f07f31f7155455e1eb7fb65596d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ Changelog = "https://github.com/containers/omlmd/releases"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-oras = "^0.2.1"
+oras = "^0.2.21"
 pyyaml = "^6.0.1"
 click = "^8.1.7"
 cloup = "^3.0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ Changelog = "https://github.com/containers/omlmd/releases"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-oras = "^0.1.30"
+oras = "^0.2.1"
 pyyaml = "^6.0.1"
 click = "^8.1.7"
 cloup = "^3.0.5"


### PR DESCRIPTION
Following on the work done on oras-project/oras-py/pull/150, we got chunked upload support, which enables us to upload large files e.g. model files directly.

LMK how you'd like to test this.